### PR TITLE
Add language attribute to test documents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: php
 matrix:
     include:
         -
+            php: '5.4'
+            env:
+                - ANALYZE=false
+        -
             php: '5.5'
             env:
                 - ANALYZE=false
@@ -32,11 +36,6 @@ matrix:
             php: '5.4'
             env:
                 - ANALYZE=false
-        # https://github.com/guzzle/guzzle/issues/1750
-        -
-            php: 'nightly'
-            env:
-                - ANALYZE=true
 before_script:
     - composer update
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: php
 matrix:
     include:
         -
-            php: 'hhvm'
-            env:
-                - ANALYZE=false
-        -
             php: '5.5'
             env:
                 - ANALYZE=false
@@ -20,6 +16,14 @@ matrix:
                 - ANALYZE=true
         -
             php: '7.1'
+            env:
+                - ANALYZE=true
+        -
+            php: '7.2'
+            env:
+                - ANALYZE=true
+        -
+            php: '7.3'
             env:
                 - ANALYZE=true
     allow_failures:
@@ -39,7 +43,7 @@ script:
     - vendor/bin/phpunit
     - vendor/bin/php-cs-fixer fix --dry-run --verbose
     - if [ "$ANALYZE" = "true" ]; then composer global require phpstan/phpstan; fi;
-    - if [ "$ANALYZE" = "true" ]; then export PATH=~/.composer/vendor/bin:$PATH; fi;
+    - if [ "$ANALYZE" = "true" ]; then export PATH=~/.config/composer/vendor/bin:$PATH; fi;
     - if [ "$ANALYZE" = "true" ]; then phpstan analyze sources --configuration=phpstan-sources.neon --level=5; fi;
     - if [ "$ANALYZE" = "true" ]; then phpstan analyze tests --configuration=phpstan-tests.neon --level=1; fi;
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ script:
     - vendor/bin/php-cs-fixer fix --dry-run --verbose
     - if [ "$ANALYZE" = "true" ]; then composer global require phpstan/phpstan; fi;
     - if [ "$ANALYZE" = "true" ]; then export PATH=~/.config/composer/vendor/bin:$PATH; fi;
+    - if [ "$ANALYZE" = "true" ]; then phpstan --version; fi;
     - if [ "$ANALYZE" = "true" ]; then phpstan analyze sources --configuration=phpstan-sources.neon --level=5; fi;
     - if [ "$ANALYZE" = "true" ]; then phpstan analyze tests --configuration=phpstan-tests.neon --level=1; fi;
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
         -
             php: '7.0'
             env:
-                - ANALYZE=true
+                - ANALYZE=false
         -
             php: '7.1'
             env:

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kolyunya/codeception-markup-validator",
     "description": "Markup validator module for Codeception.",
-    "license": "LGPL-3.0",
+    "license": "LGPL-3.0-or-later",
     "type": "library",
     "keywords": [
         "acceptance-testing",

--- a/sources/Lib/MarkupValidator/MarkupValidatorMessage.php
+++ b/sources/Lib/MarkupValidator/MarkupValidatorMessage.php
@@ -84,7 +84,7 @@ class MarkupValidatorMessage implements MarkupValidatorMessageInterface
     /**
      * Sets message type.
      *
-     * @param string $type Message type.
+     * @param string|null $type Message type.
      *
      * @return self Returns self.
      */

--- a/sources/Module/MarkupValidator.php
+++ b/sources/Module/MarkupValidator.php
@@ -50,28 +50,28 @@ class MarkupValidator extends Module
     /**
      * Markup provider.
      *
-     * @var MarkupProviderInterface
+     * @var MarkupProviderInterface|object
      */
     private $markupProvider;
 
     /**
      * Markup validator.
      *
-     * @var MarkupValidatorInterface
+     * @var MarkupValidatorInterface|object
      */
     private $markupValidator;
 
     /**
      * Message filter.
      *
-     * @var MessageFilterInterface
+     * @var MessageFilterInterface|object
      */
     private $messageFilter;
 
     /**
      * Message printer.
      *
-     * @var MessagePrinterInterface
+     * @var MessagePrinterInterface|object
      */
     private $messagePrinter;
 

--- a/tests/Lib/MarkupValidator/DefaultMarkupProviderTest.php
+++ b/tests/Lib/MarkupValidator/DefaultMarkupProviderTest.php
@@ -55,7 +55,7 @@ class DefaultMarkupProviderTest extends TestCase
         $expectedMarkup =
             <<<HTML
                 <!DOCTYPE HTML>
-                <html>
+                <html lang="en">
                     <head>
                         <title>
                             A valid page.
@@ -100,7 +100,7 @@ HTML
         $expectedMarkup =
             <<<HTML
                 <!DOCTYPE HTML>
-                <html>
+                <html lang="en">
                     <head>
                         <title>
                             A valid page.

--- a/tests/Lib/MarkupValidator/W3CMarkupValidatorTest.php
+++ b/tests/Lib/MarkupValidator/W3CMarkupValidatorTest.php
@@ -66,7 +66,7 @@ class W3CMarkupValidatorTest extends TestCase
             array(
                 <<<HTML
                     <!DOCTYPE HTML>
-                    <html>
+                    <html lang="en">
                         <head>
                             <title>
                                 A valid page.
@@ -81,7 +81,7 @@ HTML
             array(
                 <<<HTML
                     <!DOCTYPE HTML>
-                    <html>
+                    <html lang="en">
                         <head>
                         </head>
                     </html>
@@ -101,7 +101,7 @@ HTML
             array(
                 <<<HTML
                     <!DOCTYPE HTML>
-                    <html>
+                    <html lang="en">
                         <head>
                         </head>
                         <body>

--- a/tests/Module/MarkupValidatorTest.php
+++ b/tests/Module/MarkupValidatorTest.php
@@ -205,7 +205,7 @@ class MarkupValidatorTest extends TestCase
             array(
                 <<<HTML
                     <!DOCTYPE HTML>
-                    <html>
+                    <html lang="en">
                         <head>
                             <title>
                                 A valid page.
@@ -219,7 +219,7 @@ HTML
             array(
                 <<<HTML
                     <!DOCTYPE HTML>
-                    <html>
+                    <html lang="en">
                         <head>
                         </head>
                     </html>
@@ -230,7 +230,7 @@ HTML
             array(
                 <<<HTML
                     <!DOCTYPE HTML>
-                    <html>
+                    <html lang="en">
                         <head>
                         </head>
                         <body>
@@ -247,7 +247,7 @@ HTML
             array(
                 <<<HTML
                     <!DOCTYPE HTML>
-                    <html>
+                    <html lang="en">
                         <head>
                             <title>
                                 A page with a warning.
@@ -273,7 +273,7 @@ HTML
             array(
                 <<<HTML
                     <!DOCTYPE HTML>
-                    <html>
+                    <html lang="en">
                         <head>
                             <title>
                                 A page with a warning.
@@ -298,7 +298,7 @@ HTML
             array(
                 <<<HTML
                     <!DOCTYPE HTML>
-                    <html>
+                    <html lang="en">
                         <head>
                         </head>
                     </html>


### PR DESCRIPTION
W3C validator yields a warning for the `html` element without the `lang` attribute.