### PR TITLE
bug: W3CMarkupValidator config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ The recommended way of module installation is via [composer](https://getcomposer
 composer require --dev kolyunya/codeception-markup-validator
 ```
 
+## Usage with local validation service
+You can use [nu html checker](validator.github.io/validator/) to validate your markup locally.
+```sh
+docker run -it --rm -p 8888:8888 ghcr.io/validator/validator:latest
+```
+
+And ajust your provider config
+```yaml
+class_name: AcceptanceTester
+modules:
+    enabled:
+        - Kolyunya\Codeception\Module\MarkupValidator:
+            validator:
+                class: Kolyunya\Codeception\Lib\MarkupValidator\W3CMarkupValidator
+                config:
+                    baseUri: 'http://127.0.0.1:8888/'
+                    endpoint: '/'
+```
+
 ## Usage
 Add the module to your acceptance test suit configuration:
 ```yaml

--- a/sources/Lib/MarkupValidator/W3CMarkupValidator.php
+++ b/sources/Lib/MarkupValidator/W3CMarkupValidator.php
@@ -45,8 +45,17 @@ class W3CMarkupValidator extends Component implements MarkupValidatorInterface
     {
         parent::__construct($configuration);
 
-        $this->initializeHttpClient();
         $this->initializeHttpRequestParameters();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setConfiguration(array $configuration)
+    {
+        parent::setConfiguration($configuration);
+
+        $this->initializeHttpClient();
     }
 
     /**


### PR DESCRIPTION
Make it possible to override the `W3CMarkupValidator` config.

The http client was initialize to early. First we must set the configuration.

I have also add small docs to run a local validator service.